### PR TITLE
Fixing ugly Yellow light color

### DIFF
--- a/LuxaforLyncTool/LuxaforLyncTool_Client/Process.cs
+++ b/LuxaforLyncTool/LuxaforLyncTool_Client/Process.cs
@@ -239,7 +239,7 @@ namespace LuxaforLyncTool_Client
                     _lightClient.SendColor(Color.Green);
                     break;
                 case ContactAvailability.FreeIdle:
-                    _lightClient.SendColor(Color.Yellow);
+                    _lightClient.SendColor(Color.Orange);
                     break;
                 case ContactAvailability.Offline:
                     _lightClient.SendColor(Color.Black);


### PR DESCRIPTION
Changed remaining Yellow color to an Orange that looks better on the Luxafor as "Away"